### PR TITLE
use #[cfg_attr(doc, aquamarine)]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ that aims to improve the visual component of Rust documentation through use of t
 To inline a diagram into the documentation, use the `mermaid` snippet in a doc-string:
 
 ```rust 
-# use aquamarine::aquamarine
-#[aquamarine]
+#[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
 /// graph LR
 ///     s([Source]) --> a[[aquamarine]]
@@ -32,4 +31,3 @@ To see it in action, go to the [demo crate](https://docs.rs/aquamarine-demo-crat
 ![aquamarine](resources/screenshot.png)
 
 You can learn more about `mermaid.js` and what it can do in the mermaid's [documentation MdBook](https://mermaid-js.github.io/mermaid/#/)
-

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,6 +1,6 @@
 //! A demo crate for [aquamarine](https://docs.rs/aquamarine)
 
-#[aquamarine::aquamarine]
+#[cfg_attr(doc, aquamarine::aquamarine)]
 /// A function showcasing aquamarine
 ///
 /// With aquamarine it's possible to embed Mermaid diagrams into your Rust documentation using the code snippets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@
 //!
 //! To inline a diagram into the documentation, use the `mermaid` snippet in a doc-string:
 //!
-//! ```rust 
+//! ```rust
 //! # use aquamarine::aquamarine
-//! #[aquamarine]
+//! #[cfg_attr(doc, aquamarine)]
 //! /// ```mermaid
 //! /// graph LR
 //! ///     s([Source]) --> a[[aquamarine]]
@@ -17,7 +17,7 @@
 //! ///     end
 //! /// ```
 //! pub fn example() {}
-//! ``` 
+//! ```
 //! The diagram will appear in place of the `mermaid` code block, preserving all the comments around it.
 //!
 //! You can even add multiple diagrams!


### PR DESCRIPTION
The macro is only usefull when building docs.
