### PR TITLE
Add crossorigin attribte to script tag

### DIFF
--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -90,7 +90,7 @@ fn generate_diagram_rustdoc<'a>(parts: impl Iterator<Item = &'a str>) -> TokenSt
     let preamble = iter::once(r#"<div class="mermaid">"#);
     let postamble = iter::once("</div>");
 
-    let mermaid_js_include = format!(r#"<script src="{}"></script>"#, MERMAID_JS);
+    let mermaid_js_include = format!(r#"<script src="{}" crossorigin="anonymous"></script>"#, MERMAID_JS);
     let body = preamble.chain(parts).chain(postamble).join("\n");
 
     quote! {


### PR DESCRIPTION
The crossorigin attribute defines how the browser should behave in cross origin request when fetching resources referenced by the tag. Setting this to "anonymous" prevents the browser from sending cookies or other credentials with the request and thus stops tracking. 
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin

I thought it would be nice to have this.
We sadly cannot have integrity checks as those would require pinning a certain mermaid.js version, which seems impracticable. 