### PR TITLE
fix rustdoc embedded examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! To inline a diagram into the documentation, use the `mermaid` snippet in a doc-string:
 //!
 //! ```rust
-//! # use aquamarine::aquamarine
+//! # use aquamarine::aquamarine;
 //! #[cfg_attr(doc, aquamarine)]
 //! /// ```mermaid
 //! /// graph LR
@@ -36,7 +36,7 @@
 //! 
 //! *Note*: custom theme will override the default theme
 //!
-//! ```rust
+//! ```no_run
 //! /// ```mermaid
 //! /// %%{init: {
 //! ///     'theme': 'base',


### PR DESCRIPTION

Running `cargo test` resulted in several errors:
```cargo
running 8 tests
test attrs::tests::split_attr_body_tests::multiline_termination ... ok
test attrs::tests::split_attr_body_tests::carry_over ... ok
test attrs::tests::split_attr_body_tests::multiline_termination_single_token ... ok
test attrs::tests::split_attr_body_tests::multiline_termination_carry ... ok
test attrs::tests::split_attr_body_tests::one_line_one_diagram ... ok
test attrs::tests::split_attr_body_tests::other_snippet ... ok
test attrs::tests::split_attr_body_tests::one_line_multiple_diagrams ... ok
test attrs::tests::temp_split_inclusive ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests aquamarine

running 3 tests
test src/lib.rs - (line 8) ... FAILED
test src/lib.rs - (line 39) ... FAILED
test src/lib.rs - aquamarine (line 73) ... ok

failures:

---- src/lib.rs - (line 8) stdout ----
error: expected one of `::`, `;`, or `as`, found `#`
 --> src/lib.rs:10:1
  |
4 | use aquamarine::aquamarine
  |                           - expected one of `::`, `;`, or `as`
5 | #[cfg_attr(doc, aquamarine)]
  | ^ unexpected token

error: aborting due to previous error

Couldn't compile the test.
---- src/lib.rs - (line 39) stdout ----
error[E0585]: found a documentation comment that doesn't document anything
  --> src/lib.rs:51:1
   |
14 | /// ```
   | ^^^^^^^
   |
   = help: doc comments must come before what they document, maybe a comment was intended with `//`?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0585`.
Couldn't compile the test.

failures:
    src/lib.rs - (line 39)
    src/lib.rs - (line 8)

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s

error: test failed, to rerun pass '--doc'
```

This pull request will fix rustdoc test errors. :smile: 