### PR TITLE
Include minimum rust version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![crates.io](https://img.shields.io/crates/d/aquamarine)](https://crates.io/crates/aquamarine)
 [![docs.rs](https://docs.rs/aquamarine/badge.svg)](https://docs.rs/aquamarine)
 
+*Compiler support: this crate requires rustc 1.42+*
 
 Aquamarine is a procedural macro extension for [rustdoc](https://doc.rust-lang.org/rustdoc/index.html), 
 that aims to improve the visual component of Rust documentation through use of the [mermaid.js](https://mermaid-js.github.io/mermaid/#/) diagrams.


### PR DESCRIPTION
I was searching for the minimum compiler version for my [`typestate`](https://github.com/rustype/typestate-rs) crate, which depends on `aquamarine`.
I found `aquamarine` depends on `matches!` which was stabilized in 1.42, hence the addition.