### PR TITLE
build(deps): update `itertools` 0.9 -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 quote = "1"
 proc-macro2 = "1"
 proc-macro-error = "1"
-itertools = "0.9"
+itertools = "0.10"
 syn = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
NOTE: This raises the MSRV to Rust 1.32.0.