### PR TITLE
Update to syn-2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ quote = "1"
 proc-macro2 = "1"
 proc-macro-error = "1"
 itertools = "0.10"
-syn = "1"
+syn = "2.0.1"
 include_dir = "0.7"
 [dev-dependencies]
 pretty_assertions = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub fn aquamarine(_args: TokenStream, input: TokenStream) -> TokenStream {
 
 fn check_input_attrs(input: &[Attribute]) {
     for attr in input {
-        if attr.path.is_ident("aquamarine") {
+        if attr.path().is_ident("aquamarine") {
             abort!(
                 attr,
                 "multiple `aquamarine` attributes on one entity are illegal"


### PR DESCRIPTION
Updates aquamarine to depend on syn-2

There aren't any direct benefits to this change, but projects which use something that uses syn-2 and use aquamarine will end up with one fewer version of syn in their build.