### PR TITLE
chore: Disable default features of proc-macro-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 quote = "1"
 proc-macro2 = "1"
-proc-macro-error = "1"
+proc-macro-error = { version = "1", default-features = false }
 itertools = "0.10"
 syn = "2"
 include_dir = "0.7"


### PR DESCRIPTION
This allows to not add syn 1 to the dependency tree as it is not used.

This is a simpler alternative to #45 to remove the dependency on syn 1 and can be included in a bugfix release so downstream projects can benefit from it easily.