### PR TITLE
Update to use latest mermaid version for access to new diagram types

### DIFF
--- a/demo/diagram_2.mmd
+++ b/demo/diagram_2.mmd
@@ -1,0 +1,5 @@
+packet-beta
+0-15: "Option Length"
+16-23: "Option Type"
+24: "Discardable Flag"
+25-31: "Reserved = 0x00"

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -4,7 +4,7 @@
 /// A function showcasing aquamarine defaults
 ///
 /// With aquamarine it's possible to embed Mermaid diagrams into your Rust documentation using the code snippets
-/// 
+///
 /// ```mermaid
 /// graph LR
 ///     s([Source]) --> a[[aquamarine]]
@@ -28,8 +28,8 @@ pub fn example() {}
 /// %%{init: {
 ///     'theme': 'base',
 ///     'themeVariables': {
-///            'primaryColor': '#ffcccc', 
-///            'edgeLabelBackground':'#ccccff', 
+///            'primaryColor': '#ffcccc',
+///            'edgeLabelBackground':'#ccccff',
 ///            'tertiaryColor': '#fff0f0' }}}%%
 /// graph TD
 ///      A(Diagram needs to be drawn) --> B{Does it have 'init' annotation?}
@@ -42,14 +42,18 @@ pub fn example_with_styling() {}
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// A diagram can be loaded from a file as well!
-/// 
+///
 /// include_mmd!("diagram_0.mmd")
-/// 
+///
 /// Reduce clutter in your doc comments, when a diagram is big enough.
-/// 
+///
 /// You can include multiple diagrams in a single doc comment, using the macro-like syntax `include_mmd!("/path/to/diagram.mmd")`
-/// 
+///
 /// include_mmd!(diagram_1.mmd)
+///
+/// Diagrams up to Mermaid version 11.1 are currently supported
+///
+/// include_mmd!(diagram_2.mmd)
 ///
 /// **Note:** `indlude_mmd!` syntax is only supported inside doc comments
 pub fn example_load_from_file() {}

--- a/scripts/package_mermaid_release.sh
+++ b/scripts/package_mermaid_release.sh
@@ -6,7 +6,7 @@
 # Usage: scripts/package_mermaid_release.sh doc/js https://cdn.jsdelivr.net/npm/mermaid@10/dist/ mermaid.esm.min.mjs
 
 PKG_DIR="${1:-./doc/js}"
-PKG_URL="${2:-https://cdn.jsdelivr.net/npm/mermaid@10.0.2/dist/}"
+PKG_URL="${2:-https://cdn.jsdelivr.net/npm/mermaid@11.1.0/dist/}"
 PKG_NAME="${3:-mermaid.esm.min.mjs}"
 
 DOWNLOAD_DIR="${PKG_DIR}.dl"

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -16,7 +16,7 @@ static MERMAID_JS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/doc/js/");
 //  base=document.getElementById("rustdoc-vars").attributes["data-root-path"]
 const MERMAID_JS_LOCAL: &str = "static.files.mermaid/mermaid.esm.min.mjs";
 const MERMAID_JS_LOCAL_DIR: &str = "static.files.mermaid";
-const MERMAID_JS_CDN: &str = "https://unpkg.com/mermaid@10/dist/mermaid.esm.min.mjs";
+const MERMAID_JS_CDN: &str = "https://unpkg.com/mermaid@11.1/dist/mermaid.esm.min.mjs";
 
 const UNEXPECTED_ATTR_ERROR: &str =
     "unexpected attribute inside a diagram definition: only #[doc] is allowed";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,6 @@
 //! ///
 //! /// Diagram #2
 //! /// include_mmd!("diagram_2.mmd")
-//! ///
-//! /// Diagram #3
-//! /// include_mmd!("diagram_2.mmd")
 //! # fn example() {}
 //! ```
 //! [Demo on docs.rs](https://docs.rs/aquamarine-demo-crate/0.5.0/aquamarine_demo_crate/fn.example_load_from_file.html)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@
 //! ///
 //! /// Diagram #2
 //! /// include_mmd!("diagram_2.mmd")
+//! ///
+//! /// Diagram #3
+//! /// include_mmd!("diagram_2.mmd")
 //! # fn example() {}
 //! ```
 //! [Demo on docs.rs](https://docs.rs/aquamarine-demo-crate/0.5.0/aquamarine_demo_crate/fn.example_load_from_file.html)


### PR DESCRIPTION
Updated mermaid version to 11.1 in order to gain access to packet type.