### PR TITLE
Use proc-macro-error2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 quote = "1"
 proc-macro2 = "1"
-proc-macro-error = { version = "1", default-features = false }
+proc-macro-error2 = { version = "2", default-features = false }
 itertools = "0.10"
 syn = "2"
 include_dir = "0.7"

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -2,7 +2,7 @@ use include_dir::{include_dir, Dir};
 use itertools::Itertools;
 use proc_macro::Span;
 use proc_macro2::TokenStream;
-use proc_macro_error::{abort, emit_call_site_warning, emit_error};
+use proc_macro_error2::{abort, emit_call_site_warning, emit_error};
 use quote::quote;
 use std::fs;
 use std::path::Path;

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::{iter, path::PathBuf};
 use syn::{Attribute, Ident, MetaNameValue};
 
-// embedded JS code being inserted as html script elmenets
+// embedded JS code being inserted as html script elements
 static MERMAID_JS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/doc/js/");
 
 // Note: relative path depends on sub-module the macro is invoked in:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use proc_macro_error::{abort, proc_macro_error};
+use proc_macro_error2::{abort, proc_macro_error};
 
 use quote::quote;
 use syn::{parse_macro_input, Attribute};


### PR DESCRIPTION
This will avoid some rustsec advisories on downstream users of this awesome lib :)